### PR TITLE
Add main entrypoint that loads a file; fix wasi_unstable

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,49 +1,18 @@
 #include <cstdio>
 #include <cstdlib> 
-#include "gtest/gtest.h"
 
 #include "codegen_context.hpp"
 
-extern bool g_is_update_expected_mode;
-bool g_is_update_expected_mode = false;
-
-namespace {
-
-void PrintInformation()
-{
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-    printf("--------------- General Information ---------------\n");
-    printf("Host:         ");
-    fflush(stdout);
-    std::ignore = system("whoami | tr -d '\\n' && printf '@' && cat /etc/hostname");
-    printf("Build flavor: %s\n", TOSTRING(BUILD_FLAVOR));
-    printf("---------------------------------------------------\n");
-#undef TOSTRING
-#undef STRINGIFY
-}
-
-}	// annoymous namespace
+void test_main(char* filename);
 
 int main(int argc, char **argv)
 {
-    PrintInformation();
-
-    ::testing::InitGoogleTest(&argc, argv);
-
-    for (int i = 1; i < argc; i++)
-    {
-        if (strcmp(argv[i], "--update-expected") == 0)
-        {
-            g_is_update_expected_mode = true;
-        }
-        else
-        {
-            printf("Unknown command-line argument: %s\n", argv[i]);
-            ReleaseAssert(false);
-        }
-    }
-
-    return RUN_ALL_TESTS();
+  if (argc <= 1) {
+    printf("wasmnow: no input files\n");
+    return 0;
+  }
+  
+  test_main(argv[1]);
+  return 0;
 }
 

--- a/wasi_impl.cpp
+++ b/wasi_impl.cpp
@@ -359,18 +359,31 @@ uint32_t SimpleWasiImpl::fd_write(uintptr_t params)
     return __WASI_ERRNO_SUCCESS;
 }
 
+uint32_t SimpleWasiImpl::poll_oneoff(uintptr_t params)
+{
+  return params == 0 ? 0 : 0;
+}
+
+uint32_t SimpleWasiImpl::random_get(uintptr_t params)
+{
+  return params == 0 ? 0 : 0;
+}
+
+
 std::map< std::pair<std::string, std::string>, uintptr_t> g_wasiLinkMapping =
 {
-    { { "wasi_unstable", "fd_prestat_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_prestat_get) },
-    { { "wasi_unstable", "fd_prestat_dir_name"}, reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_prestat_dir_name) },
-    { { "wasi_unstable", "environ_sizes_get"},   reinterpret_cast<uintptr_t>(&SimpleWasiImpl::environ_sizes_get) },
-    { { "wasi_unstable", "environ_get"},         reinterpret_cast<uintptr_t>(&SimpleWasiImpl::environ_get) },
-    { { "wasi_unstable", "args_sizes_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::args_sizes_get) },
-    { { "wasi_unstable", "args_get"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::args_get) },
-    { { "wasi_unstable", "clock_time_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::clock_time_get) },
-    { { "wasi_unstable", "proc_exit"},           reinterpret_cast<uintptr_t>(&SimpleWasiImpl::proc_exit) },
-    { { "wasi_unstable", "fd_fdstat_get"},       reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_fdstat_get) },
-    { { "wasi_unstable", "fd_close"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_close) },
-    { { "wasi_unstable", "fd_seek"},             reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_seek) },
-    { { "wasi_unstable", "fd_write"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_write) }
+    { { "wasi_snapshot_preview1", "fd_prestat_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_prestat_get) },
+    { { "wasi_snapshot_preview1", "fd_prestat_dir_name"}, reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_prestat_dir_name) },
+    { { "wasi_snapshot_preview1", "environ_sizes_get"},   reinterpret_cast<uintptr_t>(&SimpleWasiImpl::environ_sizes_get) },
+    { { "wasi_snapshot_preview1", "environ_get"},         reinterpret_cast<uintptr_t>(&SimpleWasiImpl::environ_get) },
+    { { "wasi_snapshot_preview1", "args_sizes_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::args_sizes_get) },
+    { { "wasi_snapshot_preview1", "args_get"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::args_get) },
+    { { "wasi_snapshot_preview1", "clock_time_get"},      reinterpret_cast<uintptr_t>(&SimpleWasiImpl::clock_time_get) },
+    { { "wasi_snapshot_preview1", "proc_exit"},           reinterpret_cast<uintptr_t>(&SimpleWasiImpl::proc_exit) },
+    { { "wasi_snapshot_preview1", "fd_fdstat_get"},       reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_fdstat_get) },
+    { { "wasi_snapshot_preview1", "fd_close"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_close) },
+    { { "wasi_snapshot_preview1", "fd_seek"},             reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_seek) },
+    { { "wasi_snapshot_preview1", "poll_oneoff"},         reinterpret_cast<uintptr_t>(&SimpleWasiImpl::poll_oneoff) },
+    { { "wasi_snapshot_preview1", "random_get"},          reinterpret_cast<uintptr_t>(&SimpleWasiImpl::random_get) },
+    { { "wasi_snapshot_preview1", "fd_write"},            reinterpret_cast<uintptr_t>(&SimpleWasiImpl::fd_write) }
 };

--- a/wasi_impl.h
+++ b/wasi_impl.h
@@ -16,6 +16,8 @@ struct SimpleWasiImpl
     static uint32_t fd_close(uintptr_t);
     static uint32_t fd_seek(uintptr_t);
     static uint32_t fd_write(uintptr_t);
+    static uint32_t poll_oneoff(uintptr_t);
+    static uint32_t random_get(uintptr_t);
 };
 
 extern std::map< std::pair<std::string, std::string>, uintptr_t> g_wasiLinkMapping;


### PR DESCRIPTION
Hello,

This commit refactors the main program to load a Wasm file and run it. It adds instrumentation and changes the name of the wasi module from `wasi_unstable` to `wasi_snapshot_preview1`.

More work needs to be done to vet if WasmNow can run programs properly.